### PR TITLE
Main is an alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Used for search by keyword. Helps make your package easier to discover without p
 
 #### main [string|array of strings]
 
-The primary filename to use as an alias for the package name. Any "requires" or "imports" of the package name symbol should reference this file instead. If `main` is omitted, its default value is `index`. While Bower does not directly use these files, they are listed with the commands `bower list --json` and `bower list --paths`, so they can be used by build tools.
+The primary filename to use as an alias for the package name. Any "requires" or "imports" of the package name symbol should reference this file instead. While Bower does not directly use these files, they are listed with the commands `bower list --json` and `bower list --paths`, so they can be used by build tools.
 
 * Coffeescript should be compiled.
 * Do not include minified files.


### PR DESCRIPTION
Regardless of an extension to `main` being accepted #7, I want to clarify the original `main` intent and how build tools are already using it.

`main` is a way to alias the package name to a file inside the package. Its a convenience to package authors so they can organize their internal directories however they wish but still export there module as a simple symbol.

Bower already understands the `index.js` convention. Again taken from node, but Sprockets also supports it as well. When you install a package from a url, it writes to `foo/index.js`. `index.js` is the implicit value of `main`.

`index` is fine, but not everything wants to name their file that in the package. `main` is a way to rewrite that path to another.
