### PR TITLE
paths Proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,23 @@ The primary acting files necessary to use your package. While Bower does not dir
 * Do not include minified files.
 * Files names should not be versioned (Bad: package.1.1.0.js; Good: package.js).
 
+### paths [hash]
+
+A set of path aliases for nested files in the package other than main.
+
+* Key should include a file extension
+* Key should not include the package name as a prefix (Bad: package/bar.js, Good: barjs)
+* Key maybe the name of an existing filename (thus shaddowing it)
+* Value should include a file extension
+* Value should be relative to the package root
+
+```
+"paths": {
+  "modal.css": "css/modal.css",
+  "modal.js": "js/modal.js",
+  "button.js": "js/scrollspy.js"
+}
+```
 
 ---
 


### PR DESCRIPTION
The one line pitch, `paths` are aliases like `main` for subassets.

We've discussed this a bunch of times without putting forward any action. This has been on my wishlist for a while. Its definitely a new "feature" unlike `main` which has actually existed since the beginning.

`main` serves the majority of packages well that offer a simple single entry point into the package. However, theres a class of packages that want to expose many submodules to the user in a nice way. If you care about the ascetics of paths, you are forced to put all your assets at the root of the package. This is not ideal.

I'll use bootstrap as an example from here on.

``` js
{
  "main": "styles/bootstrap.less",
  "paths": {
    "grid.less": "styles/grid.less",
    "modals.less": "styles/modals.less",
    "modals.js": "js/modals.js",
    "scrollspy.js": "js/scrollspy.js",
    "icons.eot": "fonts/glyphicons-halflings-regular.eot"
  }
}
```

The syntax here is much like RequireJS's `paths` config. However, we need to be clear about file extensions since we aren't just deal with `.js`. Heres how [grunt-bower-requirejs](https://github.com/yeoman/grunt-bower-requirejs) would interpret this config and autogenerate the following.

``` js
requirejs.config({
  baseUrl: './',
  paths: {
    'bootstrap/modals': 'bower_components/bootstrap/js/modals',
    'bootstrap/scrollspy': 'bower_components/bootstrap/js/scrollspy'
  }
});
```
### Resources
- [josh/rails-behaviors](https://github.com/josh/rails-behaviors) - I'm forced to put all my files at the root here since I actually want nice requires. Otherwise I'd put my files into `lib/` or `src/`.
- [Modernizr](https://github.com/Modernizr/Modernizr) - Most of the optional feature detects are under `feature-detects`. It might be nicer to expose them as `modernizr/geolocation` etc.
