### PR TITLE
Fix syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,9 @@ URL to learn more about the package. Falls back to GitHub project if not specifi
 The repository in which the source code can be found.
 
 ```json
-"repository: {
+"repository": {
   "type": "git", "url": "git://github.com/foo/bar.git"
-}"
+}
 ```
 
 ---


### PR DESCRIPTION
The code of the section 'repository' contains a syntax error.

This (^ shows the error):

``` json
"repository: {
           ^
   "type": "git", "url": "git://github.com/foo/bar.git"
}"
 ^
```

should be:

``` json
"repository": {
   "type": "git", "url": "git://github.com/foo/bar.git"
}
```
