### PR TITLE
Main should be a place for libraries, not sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The package's semantic version number.
 *Recommended*  
 Type: `String` or `Array` of `String`
 
-The entry-point files necessary to use your package. Only one file per filetype.
+The entry-point files necessary to use your package. Only one file per filetype. The files that are offered should be representing your package as library. This means that the files can be used without compiling for use by the consuming party.
 
 Entry-point files have module exports and may use module imports. While Bower does not directly use `main` files, they are listed with the commands `bower list --json` and `bower list --paths`, so they can be used by build tools.
 
@@ -81,6 +81,10 @@ Let's say your package looks like this:
 "main": [
   "js/motion.js",
   "sass/motion.scss",
+  "img/motion.png",
+  "fonts/icons.woff",
+  "fonts/icons.woff2",
+  "dist/movement.css"
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -81,9 +81,6 @@ Let's say your package looks like this:
 "main": [
   "js/motion.js",
   "sass/motion.scss",
-  "img/motion.png",
-  "fonts/icons.woff",
-  "fonts/icons.woff2",
   "dist/movement.css"
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The package's semantic version number.
 *Recommended*  
 Type: `String` or `Array` of `String`
 
-The entry-point files necessary to use your package. Only one file per filetype. The files that are offered should be representing your package as library. This means that the files can be used without compiling for use by the consuming party.
+The entry-point files necessary to use your package. Only one file per filetype. The files that are offered should be representing your package as library. This means that the files can be used without compiling for use by the consuming party. This is not limited to **only** the 'compiled' version. In case of `.less`, `.scss` or `(d).ts` etc. they can be used as library aswell when used in the consuming party source.
 
 Entry-point files have module exports and may use module imports. While Bower does not directly use `main` files, they are listed with the commands `bower list --json` and `bower list --paths`, so they can be used by build tools.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The package's semantic version number.
 *Recommended*  
 Type: `String` or `Array` of `String`
 
-The entry-point files necessary to use your package. Only one file per filetype. The files that are offered should be representing your package as library. This means that the files can be used without compiling for use by the consuming party. This is not limited to **only** the 'compiled' version. In case of `.less`, `.scss` or `(d).ts` etc. they can be used as library aswell when used in the consuming party source.
+The entry-point files necessary to use your package. Only one file per filetype. The files that are offered should be representing your package as library. This means that the files can be used without compiling for use by the consuming party. This is not limited to **only** the 'compiled' version. In case of `.less`, `.scss` or `(d).ts` etc. they can be used as library as well when used in the consuming party source.
 
 Entry-point files have module exports and may use module imports. While Bower does not directly use `main` files, they are listed with the commands `bower list --json` and `bower list --paths`, so they can be used by build tools.
 


### PR DESCRIPTION
The main should contain files that can be used as library, not as sources. They can also contain the sources in forms of `less`, `sass`, or even `d.ts` files, so that the consuming party can choose based on filetype what to use and include in the project. Arguably even `.min.js` can also be added as it's the 'definitive' version of a 'compiled' library.

See also twbs/bootstrap compliance to the spec issues: https://github.com/twbs/bootstrap/issues/16663
