### PR TITLE
Fixed cwd example inconsistency

### DIFF
--- a/config.md
+++ b/config.md
@@ -25,7 +25,7 @@ The same keys can be used under `config` key in package.json
 Available configuration variables, in `.bowerrc.` format:
 
 <pre><code>{
-  <a href="#cwd">"cwd"</a>: "~/.my-project",
+  <a href="#cwd">"cwd"</a>: "~/my-project",
   <a href="#directory">"directory"</a>: "bower_components",
   <a href="#registry">"registry"</a>: "https://bower.herokuapp.com",
   <a href="#shorthand-resolver">"shorthand-resolver"</a>: "git://github.com/{{owner}}/{{package}}.git",


### PR DESCRIPTION
The main configuration sample provided has `"cwd": "~/.my-project"` listed as an example while the documentation on cwd usage has `"cwd": "~/my-project"`. This is just something really small and insignificant that I noticed, but it didn't make a lot of sense to me to have `.my-project` be a hidden directory since it is the root of the project. 