### PR TITLE
Add tmp config in the to object.

### DIFF
--- a/config.md
+++ b/config.md
@@ -41,6 +41,7 @@ Available configuration variables, in `.bowerrc.` format:
     "links" : "~/.bower/links"
   },
   <a href="#interactive">"interactive"</a>: true,
+  <a href="#temp">"temp"</a>: "./tmp/bower",
   <a href="#resolvers">"resolvers"</a>: [
     "mercurial-bower-resolver"
   ],


### PR DESCRIPTION
Add tmp config to object, as some systems do have `/tmp` access :S... And we spent some time to figure out that `temp` can be set but didn't see as part of object. Hence updating it, if it helps somebody :)